### PR TITLE
missing:Missing `!` mark for msg macro

### DIFF
--- a/snippets/rust-snippets.code-snippets
+++ b/snippets/rust-snippets.code-snippets
@@ -20,7 +20,7 @@
     },
 
     "msg": {
-        "prefix": "msg(m)",
+        "prefix": "msg!(m)",
         "body": "msg(\"${Heyo}\");",
         "description": "log msg on blockchain"
     },

--- a/snippets/rust-snippets.code-snippets
+++ b/snippets/rust-snippets.code-snippets
@@ -20,7 +20,7 @@
     },
 
     "msg": {
-        "prefix": "msg!(m)",
+        "prefix": "msg(m)",
         "body": "msg!(\"${Heyo}\");",
         "description": "log msg on blockchain"
     },

--- a/snippets/rust-snippets.code-snippets
+++ b/snippets/rust-snippets.code-snippets
@@ -21,7 +21,7 @@
 
     "msg": {
         "prefix": "msg!(m)",
-        "body": "msg(\"${Heyo}\");",
+        "body": "msg!(\"${Heyo}\");",
         "description": "log msg on blockchain"
     },
 


### PR DESCRIPTION
Missing `!` in the rust snippets, as the println! equivalent is msg! not msg which is a function, added the exclamation mark.